### PR TITLE
Fixing CS First .md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- This section is where you will replace the link to your transparent logo, the title of your project, and the very short desciptor of your project -->
 <!-- If you used Canva to make your icon and don't want to pay for a background remover, you can use the website https://www.remove.bg/ to do so -->
 <p align="center">
-  <img alt="Template Logo" src="https://github.com/jvalram/project-template/blob/main/media/logo/Transparent%20Version.png" width="" height="350" />
+  <img alt="Template Logo" src="media/logos/Transparent Version.png" width="" height="350" />
   <h1 align="center">Project Template (Example: A Game that Emphasizes the Importance of Programming Statements)</h1>
   <p align="center">A project for ... by team ... </p>
 </p>

--- a/README.md
+++ b/README.md
@@ -102,16 +102,16 @@ If you're interested in more workshops that utilize Scratch, check out [Space Me
 Your repo doesn't have to have every section used below. This is just an example so you can get an idea of what your own repo should look like</i>
 
 ### Opening a blank Scratch page 
-[Click here to view instructions](/documents/tutorial%20materials/Opening%20a%20blank%20Scratch%20page.md)
+[Click here to view instructions](/documents/tutorial_materials/Opening%20a%20blank%20Scratch%20page.md)
 
 [Video with Scratch instructions](https://youtu.be/v-GUbj7DMEE)
 
 <!-- if your project uses scratch, you can reuse any of these instructions (be sure to include CS First alternatives) -->
 ## CS First Installation Walkthrough
-[Click here to view instructions](/documents/tutorial%20materials/CS%20FIRST/CS%20First%2Walkthrough.md)
+[Click here to view instructions](/documents/tutorial_materials/CS%20FIRST/CS%20First%2Walkthrough.md)
 
 ### Getting to the game 
-[Click here to view instructions](/documents/tutorial%20materials/Getting%20to%20the%20Game.md)
+[Click here to view instructions](/documents/tutorial-materials/Getting%20to%20the%20Game.md)
 
 ## Usage
 <i> Describe HOW to use your game. </i> 
@@ -126,7 +126,7 @@ Example:
 [Demo Video on how to install and play our game](https://youtu.be/mA80Aa55t-U)
 
 ## Workshop Instructions 
-[Click here to view workshop walkthrough pdf file](/documents/tutorial%20materials/Scratch%20Workshop%20Walkthrough.pdf)
+[Click here to view workshop walkthrough pdf file](/documents/tutorial-materials/Scratch%20Workshop%20Walkthrough.pdf)
 
 [Our Game Workshop Video](https://youtu.be/Mtsre0iMStM)
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Example:
 [Demo Video on how to install and play our game](https://youtu.be/mA80Aa55t-U)
 
 ## Workshop Instructions 
-[Click here to view workshop walkthrough pdf file](/documents/tutorial-materials/Scratch%20Workshop%20Walkthrough.pdf)
+[Click here to view workshop walkthrough pdf file](/documents/tutorial%20materials/Scratch%20Workshop%20Walkthrough.pdf)
 
 [Our Game Workshop Video](https://youtu.be/Mtsre0iMStM)
 

--- a/README.md
+++ b/README.md
@@ -102,16 +102,16 @@ If you're interested in more workshops that utilize Scratch, check out [Space Me
 Your repo doesn't have to have every section used below. This is just an example so you can get an idea of what your own repo should look like</i>
 
 ### Opening a blank Scratch page 
-[Click here to view instructions](/Documents/tutorial/Opening%20a%20blank%20Scratch%20page.md)
+[Click here to view instructions](/documents/tutorial%20materials/Opening%20a%20blank%20Scratch%20page.md)
 
 [Video with Scratch instructions](https://youtu.be/v-GUbj7DMEE)
 
 <!-- if your project uses scratch, you can reuse any of these instructions (be sure to include CS First alternatives) -->
 ## CS First Installation Walkthrough
-[Click here to view instructions](/Documents/tutorial/CS%20FIRST/CS%20First%20Walkthrough.md)
+[Click here to view instructions](/documents/tutorial%20materials/CS%20FIRST/CS%20First%2Walkthrough.md)
 
 ### Getting to the game 
-[Click here to view instructions](/Documents/tutorial/Getting%20to%20the%20Game.md)
+[Click here to view instructions](/documents/tutorial%20materials/Getting%20to%20the%20Game.md)
 
 ## Usage
 <i> Describe HOW to use your game. </i> 
@@ -126,7 +126,7 @@ Example:
 [Demo Video on how to install and play our game](https://youtu.be/mA80Aa55t-U)
 
 ## Workshop Instructions 
-[Click here to view workshop walkthrough pdf file](/Documents/tutorial/Scratch%20Workshop%20Walkthrough.pdf)
+[Click here to view workshop walkthrough pdf file](/documents/tutorial%20materials/Scratch%20Workshop%20Walkthrough.pdf)
 
 [Our Game Workshop Video](https://youtu.be/Mtsre0iMStM)
 

--- a/README.md
+++ b/README.md
@@ -102,16 +102,16 @@ If you're interested in more workshops that utilize Scratch, check out [Space Me
 Your repo doesn't have to have every section used below. This is just an example so you can get an idea of what your own repo should look like</i>
 
 ### Opening a blank Scratch page 
-[Click here to view instructions](/documents/tutorial_materials/Opening%20a%20blank%20Scratch%20page.md)
+[Click here to view instructions](/documents/tutorial%20materials/Opening%20a%20blank%20Scratch%20page.md)
 
 [Video with Scratch instructions](https://youtu.be/v-GUbj7DMEE)
 
 <!-- if your project uses scratch, you can reuse any of these instructions (be sure to include CS First alternatives) -->
 ## CS First Installation Walkthrough
-[Click here to view instructions](/documents/tutorial_materials/CS%20FIRST/CS%20First%2Walkthrough.md)
+[Click here to view instructions](/documents/tutorial%20materials/CS%20FIRST/CS%20First%20Walkthrough.md)
 
 ### Getting to the game 
-[Click here to view instructions](/documents/tutorial-materials/Getting%20to%20the%20Game.md)
+[Click here to view instructions](/documents/tutorial%20materials/Getting%20to%20the%20Game.md)
 
 ## Usage
 <i> Describe HOW to use your game. </i> 

--- a/documents/tutorial materials/CS FIRST/CS First Walkthrough.md
+++ b/documents/tutorial materials/CS FIRST/CS First Walkthrough.md
@@ -6,7 +6,7 @@
 
 ### Step 1. Download the [.sb3](https://github.com/TAP-GGC/NinjaTurtles/blob/main/Code/Complete%20Code%20for%20the%20Game.sb3) file
 
-<!--- INSERT YOUR OWN .sb3 FILE IN THE PARENTHESIS!! THIS IS 1/3 LINKS YOU MUST REPLACE--->
+<!--- INSERT YOUR OWN .sb3 FILE IN THE PARENTHESIS ABOVE !! THIS IS 1/3 LINKS YOU MUST REPLACE--->
 
 The file can be found in the code folder of this repository or accessed directly through the highlighted text above. 
 
@@ -17,7 +17,7 @@ Click on 'view raw' to download (make sure to download a copy to a flash drive i
 Open CS First, click the plus sign, and select New Project.
   
 <p align="center">
-<img src = "/documents/tutorial/CS FIRST/CS First Media/cs first new project.png" width="250">
+<img src = "/documents/tutorial materials/CS FIRST/CS First Media/cs first new project.png" width="250">
 </p>
 
 - Click File
@@ -26,7 +26,7 @@ Open CS First, click the plus sign, and select New Project.
 
 
 <p align="center">
-<img src = "/documents/tutorial/CS FIRST/CS First Media/csfirst file.png" width="700">
+<img src = "/documents/tutorial materials/CS FIRST/CS First Media/csfirst file.png" width="700">
 </p>
 
 
@@ -34,7 +34,7 @@ Open CS First, click the plus sign, and select New Project.
 
 
 <p align="center">
-<img src = "/documents/tutorial/CS FIRST/CS First Media/csfirst load from computer.png" width="250">
+<img src = "/documents/tutorial materials/CS FIRST/CS First Media/csfirst load from computer.png" width="250">
 </p>
 
 >TEACHERS: Feel free to work through the workshop on your own to familiarize yourself with the lesson!


### PR DESCRIPTION
changing the tutorial folder name broke a few things in the reusable CS First guide so I wanted to help out a little and fixed up the .md to go with the new folder name